### PR TITLE
Bundler audit extractor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 * Add [reek](https://github.com/troessner/reek) extractor.
 * Add [fasterer](https://github.com/DamirSvrtan/fasterer) extractor.
+* Add [bundler-audit](https://github.com/rubysec/bundler-audit) extractor.
 
 ### v1.3.0
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,6 +4,7 @@ PATH
     repo_analyzer (1.3.0)
       brakeman
       bundler-audit
+      faraday-retry
       fasterer
       octokit (~> 4.0)
       rails (>= 6.0)
@@ -111,6 +112,8 @@ GEM
       faraday-net_http (>= 2.0, < 3.1)
       ruby2_keywords (>= 0.0.4)
     faraday-net_http (3.0.2)
+    faraday-retry (2.1.0)
+      faraday (~> 2.0)
     fasterer (0.10.1)
       colorize (~> 0.7)
       ruby_parser (>= 3.19.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,6 +3,7 @@ PATH
   specs:
     repo_analyzer (1.3.0)
       brakeman
+      bundler-audit
       fasterer
       octokit (~> 4.0)
       rails (>= 6.0)
@@ -81,6 +82,9 @@ GEM
     ast (2.4.2)
     brakeman (5.3.1)
     builder (3.2.4)
+    bundler-audit (0.9.1)
+      bundler (>= 1.2.0, < 3)
+      thor (~> 1.0)
     code_analyzer (0.5.5)
       sexp_processor
     coderay (1.1.3)

--- a/app/extractors/repo_analyzer/bundler_audit_extractor.rb
+++ b/app/extractors/repo_analyzer/bundler_audit_extractor.rb
@@ -1,0 +1,50 @@
+module RepoAnalyzer
+  class BundlerAuditExtractor < ProjectInfoExtractor
+    KEY_VALUE_REGEXP = /\A(.*):\s(.*)\z/
+
+    private
+
+    def extracted_info
+      { vulnerabilities: audit_info }
+    end
+
+    def audit_info
+      audit_collection.inject({}) do |memo, row|
+        category = nil
+
+        formatted_item = row.split("\n").inject({}) do |item, line|
+          key, value = extract_key_value_form_row(line)
+
+          if key == :criticality
+            category = value
+            memo[category] ||= []
+            next item
+          end
+
+          item[key] = value
+          item
+        end
+
+        memo[category] << formatted_item
+        memo
+      end
+    end
+
+    def audit_collection
+      collection = audit_raw_result.split("\n\n")
+      collection.pop
+      collection
+    end
+
+    def extract_key_value_form_row(line)
+      key, value = line.scan(KEY_VALUE_REGEXP).flatten
+      key = key.gsub(" ", "_").downcase.to_sym
+      [key, value]
+    end
+
+    def audit_raw_result
+      `bundle-audit update`
+      `bundle-audit check #{project_data_bridge.project_path}`
+    end
+  end
+end

--- a/lib/repo_analyzer.rb
+++ b/lib/repo_analyzer.rb
@@ -1,3 +1,4 @@
+require "bundler/audit"
 require "brakeman"
 require "fasterer"
 require "octokit"

--- a/repo_analyzer.gemspec
+++ b/repo_analyzer.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "bundler-audit"
   s.add_dependency "brakeman"
+  s.add_dependency "faraday-retry"
   s.add_dependency "fasterer"
   s.add_dependency "octokit", "~> 4.0"
   s.add_dependency "rails", ">= 6.0"

--- a/repo_analyzer.gemspec
+++ b/repo_analyzer.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |s|
   s.executables = s.files.grep(%r{^exe/}) { |f| File.basename(f) }
   s.test_files = Dir["spec/**/*"]
 
+  s.add_dependency "bundler-audit"
   s.add_dependency "brakeman"
   s.add_dependency "fasterer"
   s.add_dependency "octokit", "~> 4.0"

--- a/spec/extractors/bundler_audit_extractor_spec.rb
+++ b/spec/extractors/bundler_audit_extractor_spec.rb
@@ -1,0 +1,139 @@
+require 'rails_helper'
+
+describe RepoAnalyzer::BundlerAuditExtractor, repo_analyzer_extractor_helpers: true do
+  describe "#extract" do
+    let(:audit_result_content) do
+      <<~TEXT
+        Name: actionpack
+        Version: 6.1.7
+        CVE: CVE-2023-22792
+        GHSA: GHSA-p84v-45xj-wwqj
+        Criticality: Unknown
+        URL: https://github.com/rails/rails/releases/tag/v7.0.4.1
+        Title: ReDoS based DoS vulnerability in Action Dispatch
+        Solution: upgrade to '~> 5.2.8, >= 5.2.8.15', '~> 6.1.7, >= 6.1.7.1', '>= 7.0.4.1'
+
+        Name: actionpack
+        Version: 6.1.7
+        CVE: CVE-2023-22795
+        GHSA: GHSA-8xww-x3g3-6jcv
+        Criticality: Unknown
+        URL: https://github.com/rails/rails/releases/tag/v7.0.4.1
+        Title: ReDoS based DoS vulnerability in Action Dispatch
+        Solution: upgrade to '~> 5.2.8, >= 5.2.8.15', '~> 6.1.7, >= 6.1.7.1', '>= 7.0.4.1'
+
+        Name: activerecord
+        Version: 6.1.7
+        CVE: CVE-2022-44566
+        GHSA: GHSA-579w-22j4-4749
+        Criticality: High
+        URL: https://github.com/rails/rails/releases/tag/v7.0.4.1
+        Title: Denial of Service Vulnerability in ActiveRecord's PostgreSQL adapter
+        Solution: upgrade to '~> 5.2.8, >= 5.2.8.15', '~> 6.1.7, >= 6.1.7.1', '>= 7.0.4.1'
+
+        Name: activerecord
+        Version: 6.1.7
+        CVE: CVE-2023-22794
+        GHSA: GHSA-hq7p-j377-6v63
+        Criticality: High
+        URL: https://github.com/rails/rails/releases/tag/v7.0.4.1
+        Title: SQL Injection Vulnerability via ActiveRecord comments
+        Solution: upgrade to '~> 6.0.6, >= 6.0.6.1', '~> 6.1.7, >= 6.1.7.1', '>= 7.0.4.1'
+
+        Name: loofah
+        Version: 2.19.0
+        CVE: CVE-2022-23515
+        GHSA: GHSA-228g-948r-83gx
+        Criticality: Medium
+        URL: https://github.com/flavorjones/loofah/security/advisories/GHSA-228g-948r-83gx
+        Title: Improper neutralization of data URIs may allow XSS in Loofah
+        Solution: upgrade to '>= 2.19.1'
+
+        Name: rails-html-sanitizer
+        Version: 1.4.3
+        CVE: CVE-2022-23520
+        GHSA: GHSA-rrfc-7g8p-99q8
+        Criticality: Medium
+        URL: https://github.com/rails/rails-html-sanitizer/security/advisories/GHSA-rrfc-7g8p-99q8
+        Title: Possible XSS vulnerability with certain configurations of rails-html-sanitizer
+        Solution: upgrade to '>= 1.4.4'
+
+        Vulnerabilities found!
+      TEXT
+    end
+
+    before do
+      allow(extractor).to receive(:`).with('bundle-audit update')
+      allow(extractor).to receive(:`).with('bundle-audit check spec/assets/test_project').and_return(audit_result_content)
+    end
+
+    let(:expected) do
+      {
+        "vulnerabilities" => {
+          "Unknown" => [
+            {
+              name: "actionpack",
+              version: "6.1.7",
+              cve: "CVE-2023-22792",
+              ghsa: "GHSA-p84v-45xj-wwqj",
+              url: "https://github.com/rails/rails/releases/tag/v7.0.4.1",
+              title: "ReDoS based DoS vulnerability in Action Dispatch",
+              solution: "upgrade to '~> 5.2.8, >= 5.2.8.15', '~> 6.1.7, >= 6.1.7.1', '>= 7.0.4.1'"
+            },
+            {
+              name: "actionpack",
+              version: "6.1.7",
+              cve: "CVE-2023-22795",
+              ghsa: "GHSA-8xww-x3g3-6jcv",
+              url: "https://github.com/rails/rails/releases/tag/v7.0.4.1",
+              title: "ReDoS based DoS vulnerability in Action Dispatch",
+              solution: "upgrade to '~> 5.2.8, >= 5.2.8.15', '~> 6.1.7, >= 6.1.7.1', '>= 7.0.4.1'"
+            }
+          ],
+          "High" => [
+            {
+              name: "activerecord",
+              version: "6.1.7",
+              cve: "CVE-2022-44566",
+              ghsa: "GHSA-579w-22j4-4749",
+              url: "https://github.com/rails/rails/releases/tag/v7.0.4.1",
+              title: "Denial of Service Vulnerability in ActiveRecord's PostgreSQL adapter",
+              solution: "upgrade to '~> 5.2.8, >= 5.2.8.15', '~> 6.1.7, >= 6.1.7.1', '>= 7.0.4.1'"
+            },
+            {
+              name: "activerecord",
+              version: "6.1.7",
+              cve: "CVE-2023-22794",
+              ghsa: "GHSA-hq7p-j377-6v63",
+              url: "https://github.com/rails/rails/releases/tag/v7.0.4.1",
+              title: "SQL Injection Vulnerability via ActiveRecord comments",
+              solution: "upgrade to '~> 6.0.6, >= 6.0.6.1', '~> 6.1.7, >= 6.1.7.1', '>= 7.0.4.1'"
+            }
+          ],
+          "Medium" => [
+            {
+              name: "loofah",
+              version: "2.19.0",
+              cve: "CVE-2022-23515",
+              ghsa: "GHSA-228g-948r-83gx",
+              url: "https://github.com/flavorjones/loofah/security/advisories/GHSA-228g-948r-83gx",
+              title: "Improper neutralization of data URIs may allow XSS in Loofah",
+              solution: "upgrade to '>= 2.19.1'"
+            },
+            {
+              name: "rails-html-sanitizer",
+              version: "1.4.3",
+              cve: "CVE-2022-23520",
+              ghsa: "GHSA-rrfc-7g8p-99q8",
+              url: "https://github.com/rails/rails-html-sanitizer/security/advisories/GHSA-rrfc-7g8p-99q8",
+              title: "Possible XSS vulnerability with certain configurations of rails-html-sanitizer",
+              solution: "upgrade to '>= 1.4.4'"
+            }
+          ]
+        }
+      }.with_indifferent_access
+    end
+
+    it { expect(extract[:bundler_audit_extractor]).to eq(expected) }
+  end
+end


### PR DESCRIPTION
Adds [Bundler Audit](https://github.com/rubysec/bundler-audit) extractor to get information about gem vulnerabilities.

Output like this:
![image](https://github.com/platanus/repo_analyzer/assets/3026413/9136bfed-6a6f-49bc-8897-3f2a102aee42)

Is converted to hash like this:

![image](https://github.com/platanus/repo_analyzer/assets/3026413/60bdc846-0514-457d-9181-6e0eb2895b63)
