### PR TITLE
Analyzed project path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Unreleased
+#### Added
+
+* Run analyze rake task with custom project path.
 #### Fixed
 
 * Remove [fasterer](https://github.com/DamirSvrtan/fasterer) extractor.

--- a/app/jobs/repo_analyzer/extract_project_info_job.rb
+++ b/app/jobs/repo_analyzer/extract_project_info_job.rb
@@ -1,8 +1,8 @@
 module RepoAnalyzer
   class ExtractProjectInfoJob < ApplicationJob
-    def perform(repo_name)
+    def perform(repo_name, project_path)
       project_info = {}
-      bridge = RepoAnalyzer::ProjectDataBridge.new(repo_name)
+      bridge = RepoAnalyzer::ProjectDataBridge.new(repo_name, project_path)
 
       for_each_extractor do |extractor|
         extracted_data = extractor.new(bridge).extract

--- a/lib/tasks/repo_analyzer_tasks.rake
+++ b/lib/tasks/repo_analyzer_tasks.rake
@@ -1,7 +1,9 @@
 namespace :repo_analyzer  do
   desc "Extract repo info and post to defined endpoint"
-  task :analyze, [:repo_name] => :environment do |_t, args|
-    project_info = RepoAnalyzer::ExtractProjectInfoJob.perform_now(args.repo_name)
+  task :analyze, [:repo_name, :project_path] => :environment do |_t, args|
+    project_info = RepoAnalyzer::ExtractProjectInfoJob.perform_now(
+      args.repo_name, args.project_path
+    )
     RepoAnalyzer::PostExtractedInfoJob.perform_now(args.repo_name, project_info)
   end
 end

--- a/spec/jobs/repo_analyzer/extract_project_info_job_spec.rb
+++ b/spec/jobs/repo_analyzer/extract_project_info_job_spec.rb
@@ -2,6 +2,7 @@ require 'rails_helper'
 
 describe RepoAnalyzer::ExtractProjectInfoJob, type: :job do
   let(:repo_name) { "platanus/alisur-formulator" }
+  let(:project_path) { "spec/assets/test_project" }
 
   let(:files_list) do
     "app/extractors/repo_analyzer/project_versions_extractor.rb"
@@ -31,7 +32,7 @@ describe RepoAnalyzer::ExtractProjectInfoJob, type: :job do
   let(:engine_root) { instance_double("Pathname", join: files_list) }
 
   def perform_now
-    described_class.perform_now(repo_name)
+    described_class.perform_now(repo_name, project_path)
   end
 
   before do
@@ -44,7 +45,7 @@ describe RepoAnalyzer::ExtractProjectInfoJob, type: :job do
 
   it do
     perform_now
-    expect(RepoAnalyzer::ProjectDataBridge).to have_received(:new).with(repo_name).once
+    expect(RepoAnalyzer::ProjectDataBridge).to have_received(:new).with(repo_name, project_path).once
     expect(RepoAnalyzer::ProjectVersionsExtractor).to have_received(:new).with(bridge).once
   end
 end


### PR DESCRIPTION
I need to run the analyzer providing a rails project path instead of assuming the current path is the project path.

Before:

`bundle exec rake 'app:repo_analyzer:analyze[platanus/github-project]'`

Now:

`bundle exec rake 'app:repo_analyzer:analyze[platanus/github-project, /path/to/project]'`